### PR TITLE
Bewest/persisted data - iterate on documenting data in mongo

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,6 +32,9 @@ function getSchemaFor (o) {
     case 'cbg':
       out = diabetes.cbg;
       break;
+    case 'medtronic/bolus':
+      out = diabetes.medtronic.bolus;
+      break;
     case 'message':
       out = diabetes.message;
       break;

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ function getSchemaFor (o) {
   }
   switch (o) {
     case 'bolus':
-      out = diabetes.bolusNormal;
+      out = diabetes.bolus;
       break;
     case 'basal':
       out = diabetes.basal;

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,7 +6,7 @@ module.exports = {
     smbg: require(path.join(PREFIX, '/diabetes/smbg.json'))
   , carbs: require(path.join(PREFIX, '/diabetes/carbs.json'))
   , cbg: require(path.join(PREFIX, '/diabetes/cbg.json'))
-  , bolus: require(path.join(PREFIX, '/diabetes/bolus/pump.json'))
+  , bolus: require(path.join(PREFIX, '/diabetes/bolus/index.json'))
   , bolusNormal: require(path.join(PREFIX, '/diabetes/bolus/normal.json'))
   , bolusDual: require(path.join(PREFIX, '/diabetes/bolus/dual.json'))
   , basal: require(path.join(PREFIX, '/diabetes/basal/index.json'))

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,9 @@
 var path = require('path');
 var PREFIX = "../schemas";
 
+var medtronicSquare = require('../schemas/vendors/medtronic/square.json');
+var medtronicBolus = require('../schemas/vendors/medtronic/bolus.json');
+
 module.exports = {
     smbg: require(path.join(PREFIX, '/diabetes/smbg.json'))
   , carbs: require(path.join(PREFIX, '/diabetes/carbs.json'))
@@ -11,5 +14,6 @@ module.exports = {
   , bolusDual: require(path.join(PREFIX, '/diabetes/bolus/dual.json'))
   , basal: require(path.join(PREFIX, '/diabetes/basal/index.json'))
   , message: require(path.join(PREFIX, '/message.json'))
+  , medtronic: { square: medtronicSquare, bolus: medtronicBolus }
 };
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "scripts": {
     "test": "make test"
   },
+  "directories": {
+    "schemas": "./schemas/",
+    "lib": "./lib/"
+  },
   "bin": {
     "tidepool-validate": "bin/tidepool-validate"
   },

--- a/schemas/diabetes.json
+++ b/schemas/diabetes.json
@@ -1,7 +1,7 @@
 {
   "title": "Diabetes Records",
   "name": "Diabetes",
-  "description": "Tidepool's data model.",
+  "description": "Tidepool's data model.  Describes visualization expectations",
   "$schema": "http://json-schema.org/draft-03/schema#",
   "id": "http://tidepool-org.github.io/data-model/schemas/diabetes.json",
   "type": "array",

--- a/schemas/diabetes/bolus/dual.json
+++ b/schemas/diabetes/bolus/dual.json
@@ -6,46 +6,46 @@
 	"properties":{
 		"deviceTime": {
 			"type":"string",
-			"id": "http://jsonschema.net/deviceTime",
+			"id": "http://jsonschema.net/bolus/dual/deviceTime",
 			"required":true
 		},
 		"duration": {
 			"type":"number",
-			"id": "http://jsonschema.net/duration",
+			"id": "http://jsonschema.net/bolus/dual/duration",
 			"required":true
 		},
 		"extendedDelivery": {
 			"type":"number",
-			"id": "http://jsonschema.net/extendedDelivery",
+			"id": "http://jsonschema.net/bolus/dual/extendedDelivery",
 			"required":true
 		},
 		"extended": {
 			"type":"boolean",
-			"id": "http://jsonschema.net/extended",
+			"id": "http://jsonschema.net/bolus/dual/extended",
 			"required":true
 		},
 		"id": {
 			"type":"string",
-			"id": "http://jsonschema.net/id",
+			"id": "http://jsonschema.net/bolus/dual/id",
 			"required":false
 		},
 		"initialDelivery": {
 			"type":"number",
-			"id": "http://jsonschema.net/initialDelivery",
+			"id": "http://jsonschema.net/bolus/dual/initialDelivery",
 			"required":true
 		},
 		"recommended": {
 			"type":"number",
-			"id": "http://jsonschema.net/recommended",
+			"id": "http://jsonschema.net/bolus/dual/recommended",
 			"required":true
 		},
 		"type": {
-			"enum": ["bolus", "bolus-dual"],
+			"enum": ["bolus", "bolus-dual", "bolus-dual/square"],
 			"required":true
 		},
 		"value": {
 			"type":"number",
-			"id": "http://jsonschema.net/value",
+			"id": "http://jsonschema.net/bolus/dual/value",
 			"required":true
 		}
 	}

--- a/schemas/diabetes/bolus/index.json
+++ b/schemas/diabetes/bolus/index.json
@@ -1,17 +1,15 @@
 {
-  "title": "Basal use",
-  "name": "Basal",
-  "description": "basal usage",
+  "title": "Insulin use",
+  "name": "Bolus",
+  "description": "Insulin usage expressed as bolus doses",
   "$schema": "http://json-schema.org/draft-03/schema#",
   "id": "http://tidepool-org.github.io/data-model/schemas/diabetes/bolus/index.json",
   "type": "object",
-  "properties": {
-    "anyOf": [
+    "oneOf": [
       { "$ref": "./dual.json" },
       { "$ref": "./pump.json" },
       { "$ref": "./square.json" },
       { "$ref": "./normal.json" }
     ]
-  }
 }
 

--- a/schemas/diabetes/bolus/normal.json
+++ b/schemas/diabetes/bolus/normal.json
@@ -21,7 +21,7 @@
 			"required":false
 		},
 		"type": {
-			"enum": ["bolus", "bolus-dual", "bolus-normal"],
+			"enum": ["bolus", "bolus-dual/normal", "bolus-normal"],
 			"required":true
 		},
 		"value": {

--- a/schemas/diabetes/bolus/normal.json
+++ b/schemas/diabetes/bolus/normal.json
@@ -20,6 +20,11 @@
 			"id": "http://jsonschema.net/recommended",
 			"required":false
 		},
+		"programmed": {
+			"type":"number",
+			"id": "http://jsonschema.net/bolus/programmed",
+			"required":false
+		},
 		"type": {
 			"enum": ["bolus", "bolus-dual/normal", "bolus-normal"],
 			"required":true

--- a/schemas/diabetes/bolus/pump.json
+++ b/schemas/diabetes/bolus/pump.json
@@ -6,30 +6,29 @@
   "properties":{
     "deviceTime": {
       "type":"string",
-      "id": "types/deviceTime",
       "description": "time observed by device, ISO 8601 sans timezone",
       "required":true
     },
     "recommended": {
       "type":"number",
-      "id": "http://jsonschema.net/recommended",
+      "id": "http://jsonschema.net/bolus/pump/recommended",
       "description": "Amount of insulin recommended by bolus wizard",
       "required":false
     },
     "units": {
       "type": "string",
-      "id": "http://jsonschema.net/type/units",
+      "id": "http://jsonschema.net/type/bolus/pump/units",
       "default": "U",
       "required": false
     },
     "type": {
       "enum": ["bolus"],
-      "id": "http://jsonschema.net/type/bolus",
+      "id": "http://jsonschema.net/type/bolus/pump",
       "required":true
     },
     "value": {
       "type":"number",
-      "id": "http://jsonschema.net/type/value/",
+      "id": "http://jsonschema.net/type/bolus/pump/value/",
       "required":true
     }
   }

--- a/schemas/diabetes/bolus/square.json
+++ b/schemas/diabetes/bolus/square.json
@@ -36,7 +36,7 @@
 			"required":true
 		},
 		"type": {
-			"enum": [ "bolus", "bolus-square" ],
+			"enum": [ "bolus", "bolus-dual/square" ],
 			"id": "http://jsonschema.net/bolus/square/type",
 			"required":true
 		},

--- a/schemas/diabetes/bolus/square.json
+++ b/schemas/diabetes/bolus/square.json
@@ -11,7 +11,7 @@
 			"required":true
 		},
 		"duration": {
-			"type":"number",
+			"type":["string", "number"],
 			"id": "http://jsonschema.net/bolus/square/duration",
 			"required":true
 		},
@@ -35,13 +35,18 @@
 			"id": "http://jsonschema.net/bolus/square/recommended",
 			"required":true
 		},
+		"programmed": {
+			"type":"number",
+			"id": "http://jsonschema.net/bolus/programmed",
+			"required":false
+		},
 		"type": {
 			"enum": [ "bolus", "bolus-dual/square" ],
 			"id": "http://jsonschema.net/bolus/square/type",
 			"required":true
 		},
 		"value": {
-			"type":"number",
+			"type": ["string", "number"],
 			"id": "http://jsonschema.net/bolus/square/value",
 			"required":true
 		}

--- a/schemas/persisted.json
+++ b/schemas/persisted.json
@@ -1,0 +1,16 @@
+{
+  "title": "Persisted records",
+  "name": "Persisted",
+  "description": "Tidepool's mongo db records.",
+  "$schema": "http://json-schema.org/draft-03/schema#",
+  "id": "http://tidepool-org.github.io/data-model/schemas/persisted.json",
+  "type": "array",
+  "items": {
+    "anyOf": [
+      { "$ref": "diabetes/carbs.json" },
+      { "$ref": "diabetes/cbg.json" },
+      { "$ref": "diabetes/smbg.json" },
+      { "$ref": "message.json" }
+    ]
+  }
+}

--- a/schemas/vendors/animas.json
+++ b/schemas/vendors/animas.json
@@ -1,0 +1,12 @@
+{
+  "title": "Animas extensions",
+  "name": "Animas",
+  "description": "JSON version of Animas records from Diasend.",
+  "$schema": "http://json-schema.org/draft-03/schema#",
+  "id": "http://tidepool-org.github.io/data-model/schemas/vendors/animas.json",
+  "type": "array",
+  "items": {
+    [
+    ]
+  }
+}

--- a/schemas/vendors/animas/combination.json
+++ b/schemas/vendors/animas/combination.json
@@ -1,0 +1,71 @@
+{
+  "title": "Combination",
+  "name": "Animas combination bolus",
+  "description": "Animas combination bolus records from Diasend.",
+  "$schema": "http://json-schema.org/draft-03/schema#",
+  "id": "http://tidepool-org.github.io/data-model/schemas/vendors/animas/combination.json",
+
+	"type":"object",
+  "additionalProperties": false,
+	"properties":{
+		"deviceTime": {
+			"type":"string",
+			"id": "http://jsonschema.net/bolus/animas/deviceTime",
+			"required":true
+		},
+		"duration": {
+			"type": "string",
+			"id": "http://jsonschema.net/bolus/animas/duration",
+			"required":true
+		},
+		"extended": {
+			"type":"string",
+			"id": "http://jsonschema.net/bolus/animas/extendedDelivery",
+      "description": "Extended volume, buggy via Diasend",
+			"required":true
+		},
+		"immediate": {
+			"type":"string",
+			"id": "http://jsonschema.net/bolus/animas/immediate",
+      "description": "Immediate volume, buggy via Diasend",
+			"required":true
+		},
+		"id": {
+			"type":"string",
+			"id": "http://jsonschema.net/bolus/animas/id",
+			"required":false
+		},
+		"reason": {
+			"type":"string",
+			"id": "http://jsonschema.net/bolus/animas/reason",
+			"required":true
+		},
+		"units": {
+			"type":"string",
+			"id": "http://jsonschema.net/bolus/animas/units",
+			"required":true
+		},
+		"notes": {
+			"type":"string",
+			"id": "http://jsonschema.net/bolus/animas/notes",
+			"required":false
+		},
+		"type": {
+			"enum": [ "bolus-x-animas" ],
+			"id": "http://jsonschema.net/bolus/animas/type",
+			"required":true
+		},
+		"bolus": {
+			"type":"number",
+			"id": "http://jsonschema.net/bolus/animas/bolus",
+      "description": "Bolus volume as float",
+			"required":true
+		},
+		"value": {
+			"type":["string", "number"],
+			"id": "http://jsonschema.net/bolus/animas/value",
+      "description": "Bolus volume",
+			"required":true
+		}
+	}
+}

--- a/schemas/vendors/dexcom.json
+++ b/schemas/vendors/dexcom.json
@@ -1,0 +1,12 @@
+{
+  "title": "Dexcom extensions",
+  "name": "Dexcom",
+  "description": "JSON version of Dexcom records.",
+  "$schema": "http://json-schema.org/draft-03/schema#",
+  "id": "http://tidepool-org.github.io/data-model/schemas/vendors/dexcom.json",
+  "type": "array",
+  "items": {
+    [
+    ]
+  }
+}

--- a/schemas/vendors/medtronic.json
+++ b/schemas/vendors/medtronic.json
@@ -1,0 +1,12 @@
+{
+  "title": "Medtronic extensions",
+  "name": "Medtronic",
+  "description": "JSON version of Medtronic records from Carelink csv.",
+  "$schema": "http://json-schema.org/draft-03/schema#",
+  "id": "http://tidepool-org.github.io/data-model/schemas/vendors/animas.json",
+  "type": "array",
+  "items": {
+    [
+    ]
+  }
+}

--- a/schemas/vendors/medtronic.json
+++ b/schemas/vendors/medtronic.json
@@ -3,7 +3,7 @@
   "name": "Medtronic",
   "description": "JSON version of Medtronic records from Carelink csv.",
   "$schema": "http://json-schema.org/draft-03/schema#",
-  "id": "http://tidepool-org.github.io/data-model/schemas/vendors/animas.json",
+  "id": "http://tidepool-org.github.io/data-model/schemas/vendors/medtronic.json",
   "type": "array",
   "items": {
     [

--- a/schemas/vendors/medtronic/bolus.json
+++ b/schemas/vendors/medtronic/bolus.json
@@ -1,0 +1,12 @@
+{
+  "title": "Medtronic bolus extensions",
+  "name": "Bolus",
+  "description": "Medtronic's extensions to bolus",
+  "$schema": "http://json-schema.org/draft-03/schema#",
+  "id": "http://tidepool-org.github.io/data-model/schemas/vendors/medtronic/bolus.json",
+  "type": "object",
+  "oneOf": [
+    { "$ref": "./square.json" },
+    { "$ref": "../../diabetes/bolus/normal.json" }
+  ]
+}

--- a/schemas/vendors/medtronic/square.json
+++ b/schemas/vendors/medtronic/square.json
@@ -1,0 +1,44 @@
+{
+	"type":"object",
+	"$schema": "http://json-schema.org/draft-03/schema",
+  "id": "http://tidepool-org.github.io/data-model/schemas/vendors/medtronic/square.json",
+  "title": "Square wave bolus",
+  "additionalProperties": false,
+	"properties":{
+		"deviceTime": {
+			"type":"string",
+			"id": "http://jsonschema.net/mm/bolus/square/deviceTime",
+			"required":true
+		},
+		"duration": {
+			"type":["string", "number"],
+			"id": "http://jsonschema.net/mm/bolus/square/duration",
+			"required":true
+		},
+		"id": {
+			"type":"string",
+			"id": "http://jsonschema.net/mm/bolus/square/id",
+			"required":false
+		},
+		"programmed": {
+			"type":"number",
+			"id": "http://jsonschema.net/mm/bolus/programmed",
+			"required":false
+		},
+		"type": {
+			"enum": [ "bolus", "bolus-dual/square" ],
+			"id": "http://jsonschema.net/bolus/mm/square/type",
+			"required":true
+		},
+		"bolus": {
+			"type": "number",
+			"id": "http://jsonschema.net/bolus/mm/square/bolus",
+			"required":true
+		},
+		"value": {
+			"type": ["string", "number"],
+			"id": "http://jsonschema.net/bolus/mm/square/value",
+			"required":true
+		}
+	}
+}


### PR DESCRIPTION
## WIP

This is for transparency and discussion around what gets stored in mongo vs what the visualizations expect.

As a quick note:
- bolus and basals basically all need some kind of collation technique to prep data for vis
- in many cases the parsers cannot produce the information necessary for the visualization.  When this is the case vendor extended record types are inserted into mongo in order to avoid conflicting with the data model in untestable ways.

The following commits will attempt to document the ways in which the data stored in mongo (as produced from the parsers) differs from the visualization schema.
