### PR TITLE
require that value be a number, kill spurious prop

### DIFF
--- a/schemas/diabetes/bolus/normal.json
+++ b/schemas/diabetes/bolus/normal.json
@@ -30,14 +30,9 @@
 			"required":true
 		},
 		"value": {
-			"type": ["string", "number"],
+			"type": "number",
 			"id": "http://jsonschema.net/bolus/value",
 			"required":true
-		},
-		"bolus": {
-			"type":"number",
-			"id": "http://jsonschema.net/bolus/value/bolus",
-			"required":false
 		}
 	}
 }

--- a/schemas/diabetes/bolus/square.json
+++ b/schemas/diabetes/bolus/square.json
@@ -46,7 +46,7 @@
 			"required":true
 		},
 		"value": {
-			"type": ["string", "number"],
+			"type": "number",
 			"id": "http://jsonschema.net/bolus/square/value",
 			"required":true
 		}

--- a/schemas/diabetes/carbs.json
+++ b/schemas/diabetes/carbs.json
@@ -30,14 +30,9 @@
 			"required":false
 		},
 		"value": {
-			"type": [ "string", "number" ],
+			"type": "number",
 			"id": "http://jsonschema.net/carbs/value",
 			"required":true
-		},
-		"carbs": {
-			"type":"number",
-			"id": "http://jsonschema.net/carbs/carbs",
-			"required":false
 		}
 	}
 }

--- a/schemas/diabetes/cbg.json
+++ b/schemas/diabetes/cbg.json
@@ -24,14 +24,9 @@
 			"required":true
 		},
 		"value": {
-			"type": [ "string", "number" ],
+			"type": "number",
 			"id": "http://jsonschema.net/cbg/value",
 			"required":true
-		},
-		"cbg": {
-			"type":"number",
-			"id": "http://jsonschema.net/cbg/cbg",
-			"required":false
 		}
 	}
 }

--- a/schemas/diabetes/smbg.json
+++ b/schemas/diabetes/smbg.json
@@ -25,14 +25,9 @@
 			"required":true
 		},
 		"value": {
-			"type": [ "string", "number" ],
+			"type": "number",
 			"id": "http://jsonschema.net/smbg/value",
 			"required":true
-		},
-		"smbg": {
-			"type":"number",
-			"id": "http://jsonschema.net/value",
-			"required":false
 		}
 	}
 }


### PR DESCRIPTION
Each record had a custom property that duplicated value, but using the
name (the type) of the record as the key name for the duplicate value.
In the short term this was used to help develop the data model and get
it used in tests throughout the parsers and experiment with numeric vs
string types.  Now that we know we want numbers everywhere, we can
safely assume that there are no objects which have string "values".

Now the data model can use the $ref feature to abstract a common base
record.  All records have a type, deviceTime, and value.  Value is
always a number.
