### PR TITLE
Potential settings object

### DIFF
--- a/examples/settings.json
+++ b/examples/settings.json
@@ -4,8 +4,7 @@
     "activeBasalSchedule": "standard",
     "units": {
 	"carb": "grams",
-	"insulinSensitivity": "mg dL",
-	"bgTarget": "mg dL"
+	"bg": "mg dL"
     },
     "basalSchedules": {
 	"standard": [ 

--- a/examples/settings.json
+++ b/examples/settings.json
@@ -12,6 +12,7 @@
 	    { "rate": 0.95, "start": 0 },
 	    { "rate": 0.9, "start": 3600000 },
 	    ...
+	]
     },
     "carbRatio" : [
 	{ "amount": 12, "units": "grams", "start": 0 },
@@ -19,13 +20,13 @@
 	...
     ],
     "insulinSensitivity" : [
-	{ "amount": 65, "start": 0 },
-	{ "amount": 45, "start": 18000000 },
+	{ "amount": 65, "units": "mg dL", "start": 0 },
+	{ "amount": 45, "units": "mg dL", "start": 18000000 },
 	    ...
     ],
     "bgTarget": [
-	{ "low": 100, "high": 120, "start": 0 },
-	{ "low": 90, "high": 110, "start": 18000000 },
+	{ "low": 100, "high": 120, "units": "mg dL", "start": 0 },
+	{ "low": 90, "high": 110, "units": "mg dL", "start": 18000000 },
 	    ...
     ]
 }

--- a/examples/settings.json
+++ b/examples/settings.json
@@ -2,6 +2,11 @@
     "type": "settings",
     "deviceTime": "2014-02-17T12:12:12",
     "activeBasalSchedule": "standard",
+    "units": {
+	"carb": "grams",
+	"insulinSensitivity": "mg dL",
+	"bgTarget": "mg dL"
+    },
     "basalSchedules": {
 	"standard": [ 
 	    { "rate": 0.8, "start": 0 },
@@ -15,18 +20,18 @@
 	]
     },
     "carbRatio" : [
-	{ "amount": 12, "units": "grams", "start": 0 },
-	{ "amount": 10, "units": "grams", "start": 21600000 },
+	{ "amount": 12, "start": 0 },
+	{ "amount": 10, "start": 21600000 },
 	...
     ],
     "insulinSensitivity" : [
-	{ "amount": 65, "units": "mg dL", "start": 0 },
-	{ "amount": 45, "units": "mg dL", "start": 18000000 },
+	{ "amount": 65, "start": 0 },
+	{ "amount": 45, "start": 18000000 },
 	    ...
     ],
     "bgTarget": [
-	{ "low": 100, "high": 120, "units": "mg dL", "start": 0 },
-	{ "low": 90, "high": 110, "units": "mg dL", "start": 18000000 },
+	{ "low": 100, "high": 120, "start": 0 },
+	{ "low": 90, "high": 110, "start": 18000000 },
 	    ...
     ]
 }

--- a/examples/settings.json
+++ b/examples/settings.json
@@ -1,0 +1,31 @@
+{
+    "type": "settings",
+    "deviceTime": "2014-02-17T12:12:12",
+    "activeBasalSchedule": "standard",
+    "basalSchedules": {
+	"standard": [ 
+	    { "rate": 0.8, "start": 0 },
+	    { "rate": 0.75, "start": 3600000 },
+		...
+	],
+	"pattern a": [
+	    { "rate": 0.95, "start": 0 },
+	    { "rate": 0.9, "start": 3600000 },
+	    ...
+    },
+    "carbRatio" : [
+	{ "amount": 12, "units": "grams", "start": 0 },
+	{ "amount": 10, "units": "grams", "start": 21600000 },
+	...
+    ],
+    "insulinSensitivity" : [
+	{ "amount": 65, "start": 0 },
+	{ "amount": 45, "start": 18000000 },
+	    ...
+    ],
+    "bgTarget": [
+	{ "low": 100, "high": 120, "start": 0 },
+	{ "low": 90, "high": 110, "start": 18000000 },
+	    ...
+    ]
+}


### PR DESCRIPTION
@jebeck @skrugman @kentquirk 

This is a pull request with an example "settings" object.  I'm intending that any time even **_one**_ of the data points in these items changes, we get a brand new object with **_all**_ of the "current" values.  We will store the stream of all schedules that have existed.

Does this make sense to you?  It should be pretty straight-forward to generate this data from medtronic, I haven't dug into animas yet, though, so when I do get around to that, some things might change around.  I'm not planning on diving into animas until I'm done with medtronic stuff, though.  

Just from a high level, it seems like all pumps should have some measure of these ideas though.  The question for Animas will be more around if they expose the stuff to us or not.

Also, a point on organization of this repo.  I don't understand the organization of this repository and I just wanted to show an example file, so I put it here.  If you would rather this be somewhere else, just let me know (or feel free to just move it around).

On the names of the fields, I think they are intuitive and just make sense given the data we are working with.  I'm not attached to any of them though, if you want them changed or want an explanation of the data type, lmk.
